### PR TITLE
Update scripts Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,11 +34,10 @@ android {
 
     defaultConfig {
         applicationId "net.foucry.pilldroid"
-        minSdkVersion defaultMinSdkVersion
-        targetSdkVersion defaultTargetSdkVersion
+        minSdk defaultMinSdkVersion
+        targetSdk defaultTargetSdkVersion
         versionCode 302
         versionName "v0.302-beta"
-        multiDexEnabled true
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
@@ -59,7 +58,7 @@ android {
             signingConfig signingConfigs.release
         }
     }
-    flavorDimensions "version"
+    flavorDimensions = ["version"]
     productFlavors {
         dev {
             resValue "string", "app_name", "PillDroid dev"
@@ -77,7 +76,6 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    buildToolsVersion = "34.0.0"
     namespace 'net.foucry.pilldroid'
 
     allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ ext {
     compileSdkVersion = '28'
     buildToolsVersion = '28.0.1'
     var = '3.4.2'
-    //buildToolsVersion1 = '29.0.3'
     defaultMinSdkVersion = 26
     defaultTargetSdkVersion = 30
     defaultVersionCode = 1
@@ -35,7 +34,7 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }
 


### PR DESCRIPTION
- Replace minSdkVersion by minSdk
- Replace targetSdkVersion by defaultTargetSdkVersion
- Remove defaultTargetSdkVersion -> Not necessary on app with minSdk up as Android 5
- Fix flavorDimensions deprecation
- Remove buildToolsVersion -> now gradle use automatically compileSdk
- Update clean task to new format