### PR TITLE
Fix gradle deprecation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,9 @@ android {
             }
         }
     }
+    buildFeatures {
+      buildConfig = true
+  }
 
     buildTypes {
         debug {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,5 @@ android.useAndroidX=true
 org.gradle.unsafe.configuration-cache=true
 org.gradle.warning.mode=none
 org.gradle.unsafe.configuration-cache-problems=warn
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
With gradle 8.0, buildConfig in properties file is deprecated. We need to specify buildConfig foreach module -> https://stackoverflow.com/questions/74634321/fixing-the-build-type-contains-custom-buildconfig-fields-but-the-feature-is-di