### PR TITLE
Fix some Android Studio Warnings

### DIFF
--- a/app/src/main/assets/about.html
+++ b/app/src/main/assets/about.html
@@ -12,9 +12,10 @@
         p.red {
         color: #ff2600;
         }</style>
+    <title>About</title>
 </head>
 <body>
-<center><img src="file:///android_asset/icon_pilldroid.png" width="64"/></center>
+<div style="text-align: center;"><img src="file:///android_asset/icon_pilldroid.png" width="64"/></div>
 <!--<div class="build">[[[about_string]]]</div>-->
 <h5>Pilldroid &copy;&nbsp;2022 Jacques Foucry </h5>
 <p>Pilldroid est une gestion théorique de votre stock de médicaments.</p>

--- a/app/src/main/java/net/foucry/pilldroid/CustomScannerActivity.java
+++ b/app/src/main/java/net/foucry/pilldroid/CustomScannerActivity.java
@@ -11,8 +11,6 @@ import android.widget.ImageButton;
 
 import androidx.annotation.NonNull;
 
-import com.journeyapps.barcodescanner.BarcodeCallback;
-import com.journeyapps.barcodescanner.BarcodeResult;
 import com.journeyapps.barcodescanner.CaptureManager;
 import com.journeyapps.barcodescanner.DecoratedBarcodeView;
 import com.journeyapps.barcodescanner.ViewfinderView;

--- a/app/src/main/java/net/foucry/pilldroid/DBHelper.java
+++ b/app/src/main/java/net/foucry/pilldroid/DBHelper.java
@@ -10,7 +10,6 @@ import android.text.format.DateUtils;
 import android.util.Log;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 /**

--- a/app/src/main/java/net/foucry/pilldroid/DrugListActivity.java
+++ b/app/src/main/java/net/foucry/pilldroid/DrugListActivity.java
@@ -333,7 +333,6 @@ public class DrugListActivity extends AppCompatActivity {
 
         Log.d(TAG, "scanOptions == " + options);
         mBarcodeScannerLauncher.launch(options);
-        return;
     }
 
     /**
@@ -348,11 +347,11 @@ public class DrugListActivity extends AppCompatActivity {
         dialog.setCanceledOnTouchOutside(true);
         dialog.setContentView(R.layout.input_dialog);
 
-        Button ok = (Button) dialog.findViewById(R.id.agreed);
-        Button cancel = (Button) dialog.findViewById(R.id.notagreed);
+        Button ok = dialog.findViewById(R.id.agreed);
+        Button cancel = dialog.findViewById(R.id.notagreed);
         ok.setEnabled(false);
-        ok.setBackground(getDrawable(R.drawable.rounded_btn_disabled));
-        //TextView  title = (TextView ) dialog.findViewById(R.id.title);
+        ok.setBackground(ContextCompat.getDrawable(this, R.drawable.rounded_btn_disabled));
+        //TextView  title = dialog.findViewById(R.id.title);
         final EditText editText= dialog.findViewById(R.id.editcip13);
         String cip13 = String.valueOf(editText.getText());
 
@@ -375,7 +374,7 @@ public class DrugListActivity extends AppCompatActivity {
                 //alert.getButton(alert.BUTTON_POSITIVE).setEnabled(s.length() == 8);
                 if (s.length() == 8) {
                     ok.setEnabled(true);
-                    ok.setBackground(getDrawable(R.drawable.rounded_btn));
+                    ok.setBackground(ContextCompat.getDrawable(editText.getContext(), R.drawable.rounded_btn));
                 }
             }
         });
@@ -418,7 +417,7 @@ public class DrugListActivity extends AppCompatActivity {
             msgString = aMedicine.getName() + " " + getString(R.string.msgFound);
             msg.setText(msgString);
             cplString = getString(R.string.addInList);
-            if (cplString.equals("")) {
+            if (cplString.isEmpty()) {
                 cpl.setEnabled(false);
             }
             icon.setImageResource(R.drawable.tickmark);

--- a/app/src/main/java/net/foucry/pilldroid/Utils.java
+++ b/app/src/main/java/net/foucry/pilldroid/Utils.java
@@ -3,7 +3,6 @@ package net.foucry.pilldroid;
 import net.foucry.pilldroid.models.Medicine;
 import net.foucry.pilldroid.models.Prescription;
 
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;

--- a/app/src/main/java/net/foucry/pilldroid/WelcomeActivity.java
+++ b/app/src/main/java/net/foucry/pilldroid/WelcomeActivity.java
@@ -151,7 +151,7 @@ public class WelcomeActivity extends AppCompatActivity {
 
         msgString = getString(R.string.understood);
         msg.setText(msgString);
-        if (cplString.equals("")) {
+        if (cplString.isEmpty()) {
             cpl.setEnabled(false);
         }
         //icon.setImageResource(R.drawable.pilldroid_icon);

--- a/app/src/main/res/layout/custom_barcode_scanner.xml
+++ b/app/src/main/res/layout/custom_barcode_scanner.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:zxing_framing_rect_height="150dp"
-        app:zxing_framing_rect_width="300dp"></com.journeyapps.barcodescanner.BarcodeView>
+        app:zxing_framing_rect_width="300dp"/>
 
     <com.journeyapps.barcodescanner.ViewfinderView
         android:id="@+id/zxing_viewfinder_view"

--- a/app/src/main/res/layout/welcome_activity.xml
+++ b/app/src/main/res/layout/welcome_activity.xml
@@ -19,7 +19,7 @@
         android:layout_alignParentBottom="true"
         android:layout_marginBottom="20dp"
         android:gravity="center"
-        android:orientation="horizontal"></LinearLayout>
+        android:orientation="horizontal"/>
 
     <Button
         android:id="@+id/btn_next"


### PR DESCRIPTION
This PR fixes:
- In HTML file
  - Add title of page
  - Replace deprecated tag center by div with text align center
- Remove unused imports
- Remove redundant type in assignation
- Use `ContextCompat.getDrawable()`
- Replace `equals("")` by `isEmpty()`
- Fixes xml layout