### PR TITLE
Fix Camera crash

### DIFF
--- a/app/src/main/java/net/foucry/pilldroid/CustomScannerActivity.java
+++ b/app/src/main/java/net/foucry/pilldroid/CustomScannerActivity.java
@@ -89,6 +89,11 @@ public class CustomScannerActivity extends Activity implements DecoratedBarcodeV
     }
 
     @Override
+    public void onBackPressed(){
+        onCancel(this.getCurrentFocus());
+    }
+
+    @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         capture.onSaveInstanceState(outState);


### PR DESCRIPTION
Fixes #10 

When user use Android back button to leave `CustomScannerActivity`.Intent in `DrugListActivity` catch a null value that's cause the crash.
The solution is to call onCancel when onBackPressed is call to return a valid value to intent in `DrugListActivity`.