### PR TITLE
Remove duplicate call

### DIFF
--- a/app/src/main/java/net/foucry/pilldroid/DrugListActivity.java
+++ b/app/src/main/java/net/foucry/pilldroid/DrugListActivity.java
@@ -327,7 +327,6 @@ public class DrugListActivity extends AppCompatActivity {
         options.setBarcodeImageEnabled(true);
         options.setTimeout(60);
         options.setCaptureActivity(CustomScannerActivity.class);
-        options.setBeepEnabled(true);
         options.addExtra(Intents.Scan.SCAN_TYPE, Intents.Scan.MIXED_SCAN);
         options.addExtra(Intents.Scan.SCAN_TYPE, Intents.Scan.INVERTED_SCAN);
 


### PR DESCRIPTION
When user press button to scan, we call twice setBeepEnabled method.

![Screenshot_20240329-182251](https://github.com/jfoucry/Pilldroid/assets/87148630/6d76dc1c-ec1f-4e5b-9b8f-a68302b0507e)
