### PR TITLE
Fix buttons not appears in scanner activity

### DIFF
--- a/app/src/main/res/layout/custom_barcode_scanner.xml
+++ b/app/src/main/res/layout/custom_barcode_scanner.xml
@@ -43,12 +43,10 @@
         android:layout_margin="@dimen/fab_margin"
         android:accessibilityHeading="true"
         android:backgroundTint="@android:color/transparent"
-        android:clickable="false"
         android:contentDescription="@string/button_cancel"
         android:cropToPadding="false"
-        android:foregroundTint="@android:color/darker_gray"
-        android:onClick="onCancel"
-        app:srcCompat="@drawable/ic_cancel_black_24dp" />
+        app:background="@android:color/darker_gray"
+        android:src="@drawable/ic_cancel_black_24dp" />
 
     <ImageButton
         android:id="@+id/keyboard_button"
@@ -58,8 +56,7 @@
         android:layout_margin="@dimen/fab_margin"
         android:backgroundTint="@android:color/transparent"
         android:contentDescription="@string/button_keyboard"
-        android:onClick="onKeyboard"
-        app:srcCompat="@drawable/ic_keyboard_black_24dp"
+        android:src="@drawable/ic_keyboard_black_24dp"
         tools:ignore="PrivateResource" />
 
 </merge>

--- a/app/src/main/res/layout/custom_scanner_activty.xml
+++ b/app/src/main/res/layout/custom_scanner_activty.xml
@@ -23,8 +23,7 @@
             android:layout_marginBottom="@dimen/fab_margin"
             android:backgroundTint="@android:color/transparent"
             android:contentDescription="@string/flashlightButton"
-            android:onClick="switchFlashlight"
-            app:srcCompat="@drawable/ic_baseline_highlight_24" />
+            android:src="@drawable/ic_baseline_highlight_24" />
     </com.journeyapps.barcodescanner.DecoratedBarcodeView>
 
 </RelativeLayout>


### PR DESCRIPTION
PR #33 has introduced regressions in scanner activity -> buttons doesn't appears
I have reverted change on 3 image buttons
I have removed property `android:clickable="false"`
I have removed older property to specify which method is called when user presses a button