### PR TITLE
Improve consent dialog

### DIFF
--- a/app/src/main/java/net/foucry/pilldroid/WelcomeActivity.java
+++ b/app/src/main/java/net/foucry/pilldroid/WelcomeActivity.java
@@ -156,7 +156,6 @@ public class WelcomeActivity extends AppCompatActivity {
         btn.setOnClickListener(v -> {
             // TODO Auto-generated method stub
             dlg.dismiss();
-            finish();
         });
     }
 


### PR DESCRIPTION
At the first start, when the user presses the `I understood` button in the consent dialog -> WelcomeActivity is closed.
It's better to keep the activity open to leave users seeing the tutorial